### PR TITLE
Remove stray tab

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,7 @@ parts:
 apps:
   ybserver:
     command: ybserver
-    daemon: simple	
+    daemon: simple
     restart-condition: always
     plugs:
       - network


### PR DESCRIPTION
This caused snapcraft.yaml to fail to parse.